### PR TITLE
Reset PID controller when manual driver takes over

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -82,7 +82,8 @@ class DBWNode(object):
         # TODO: Create `TwistController` object
         min_speed = 0.0
         self.controller = Controller(wheel_base, steer_ratio, min_speed, 
-                                     max_lat_accel, max_steer_angle)
+                                     max_lat_accel, max_steer_angle,
+                                     vehicle_mass, wheel_radius, decel_limit, brake_deadband)
 
         # TODO: Subscribe to all the topics you need to
         rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb, queue_size=1)

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -20,6 +20,9 @@ of `dbw_enabled`. While in the simulator, its enabled all the time, in the real 
 not be the case. This may cause your PID controller to accumulate error because the car could
 temporarily be driven by a human instead of your controller.
 
+NOTE: When operating the simulator please check DBW status and ensure that it is in the 
+      desired state. DBW can be toggled by clicking "Manual" in the simulator GUI.
+
 We have provided two launch files with this node. Vehicle specific values (like vehicle_mass,
 wheel_base) etc should not be altered in these files.
 
@@ -87,7 +90,7 @@ class DBWNode(object):
         rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb, queue_size=1)
         
         
-        self.dbw_enabled = True
+        self.dbw_enabled = False                # Start out as false. Simulator is in manual state.
         self.target_linear_velocity = 0.0
         self.target_angular_velocity = 0.0
         self.current_linear_velocity = 0.0
@@ -137,6 +140,12 @@ class DBWNode(object):
     def dbw_enabled_cb(self, msg):
         # msg type: Bool
         self.dbw_enabled = msg.data
+        if self.dbw_enabled == False:
+            rospy.logwarn("dbw_node: DBW is disabled! Resetting pid controllers.\n")
+            self.controller.reset_pid()
+        else:
+            rospy.logwarn("dbw_node: DBW is enabled!\n")    
+            
 
     def twist_cmd_cb(self, msg):
         # msg type: TwistStamped

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -16,6 +16,7 @@ class PID(object):
     def reset(self):
         self.int_val = 0.0
         self.last_int_val = 0.0
+        self.last_error = 0.0
 
     def step(self, error, sample_time):
         self.last_int_val = self.int_val

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -10,8 +10,8 @@ ONE_MPH = 0.44704
 
 class Controller(object):
     def __init__(self, wheel_base, steer_ratio, min_speed, 
-                       max_lat_accel, max_steer_angle):
-        # TODO: Implement
+                       max_lat_accel, max_steer_angle,
+                       vehicle_mass, wheel_radius, decel_limit, brake_deadband):
         
         # controller for throttle       
         self.tc = PID(0.1, 0.002, 0.0, mx=1.0) # kp, ki, kd as taken from Term 1 pid project
@@ -20,6 +20,12 @@ class Controller(object):
         self.yc = YawController(wheel_base, steer_ratio, min_speed, 
                                 max_lat_accel, 
                                 max_steer_angle)
+        
+        # values for brake torque calculation
+        self.vehicle_mass   = vehicle_mass
+        self.wheel_radius   = wheel_radius
+        self.decel_limit    = decel_limit
+        self.brake_deadband = brake_deadband
         
         # just for testing
         self.test_0_status = 0
@@ -45,7 +51,14 @@ class Controller(object):
         if error < 0.0:
             # Need to brake
             # TODO: Calculate this from target acceleration, in unit of torque (N*m)
-            brake = -1.0E30
+            brake = -3000
+            #
+            # It is not stopping quickly enough when calculating it like this... Need to investigate.
+            # torque = mass * accel * wheel radius
+            # Take a little extra mass into account, for gas/people/etc..
+            # brake = self.vehicle_mass * self.decel_limit * self.wheel_radius  # Note: decel_limit is negative
+            #if brake > self.brake_deadband: # tolerance on brake value...
+            #    brake = 0.0
         else:    
             if sample_time > 0.0:
                 thc   = self.tc.step(error, sample_time)

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -13,8 +13,7 @@ class Controller(object):
                        max_lat_accel, max_steer_angle):
         # TODO: Implement
         
-        # controller for throttle & brake        
-        #self.tc = PID(0.1, 0.002, 0.0, mn=-0.5, mx=1.0) # kp, ki, kd as taken from Term 1 pid project
+        # controller for throttle       
         self.tc = PID(0.1, 0.002, 0.0, mx=1.0) # kp, ki, kd as taken from Term 1 pid project
         
         # controller for steer
@@ -26,6 +25,13 @@ class Controller(object):
         self.test_0_status = 0
         self.test_0_speed  = 5
 
+    def reset_pid(self):
+        """
+        Reset the PID controllers
+        This is needed if dbw node is over-ruled by safety driver.
+        """
+        self.tc.reset()
+                
     def control(self, 
                 target_linear_velocity, target_angular_velocity,
                 current_linear_velocity, current_angular_velocity,

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -98,7 +98,10 @@ class WaypointUpdater(object):
             if DEBUG:
                 rospy.logwarn("waypoint_updater: stop_line_wp_id, distance= %s, %f",str(self.red_light_stopline_wp_id), distance_to_stopline)
         
-        if self.red_light_stopline_wp_id == -1 or distance_to_stopline>DISTANCE_LIGHT_IGNORE:
+        if (self.red_light_stopline_wp_id == -1 or 
+            distance_to_stopline>DISTANCE_LIGHT_IGNORE or
+            i1 > self.red_light_stopline_wp_id # car is already past the stop line... Keep going.
+            ):
             # free & clear, drive at speed limit
             final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
             final_waypoints = self.drive_at_speed_limit(final_waypoints)        


### PR DESCRIPTION
In real life, a driver can take over. 
In the simulator, you can toggle Manual driving.
In both cases, the DBW node must pick this up, and reset the PID controller, to avoid accumulating wrong errors.
I also write a warning each time you toggle from manual to non-manual:

[WARN] [1509762892.303379]: dbw_node: DBW is enabled!

[WARN] [1509762897.909594]: dbw_node: DBW is disabled! Resetting pid controllers.

[WARN] [1509762902.669676]: dbw_node: DBW is enabled!

[WARN] [1509762908.210587]: dbw_node: DBW is disabled! Resetting pid controllers.
