### PR TITLE
Car drives around track and stops for lights

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -140,7 +140,6 @@ class TLDetector(object):
                     light_wp = -light_wp # >0: RED; <0: NOT RED!
             
             self.last_wp    = light_wp
-            rospy.logwarn("tl_detector: light_wp = %s", str(light_wp))
             self.upcoming_red_light_pub.publish(Int32(light_wp))
         else:
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -8,7 +8,7 @@ import math
 
 from twist_controller import Controller
 
-DEBUG = True
+DEBUG = False
 
 '''
 You can build this node only after you have built (or partially built) the `waypoint_updater` node.

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -14,7 +14,8 @@ class Controller(object):
                        vehicle_mass, wheel_radius, decel_limit, brake_deadband):
         
         # controller for throttle       
-        self.tc = PID(0.1, 0.002, 0.0, mx=1.0) # kp, ki, kd as taken from Term 1 pid project
+        #self.tc = PID(0.1, 0.002, 0.0, mx=1.0) # kp, ki, kd as taken from Term 1 pid project
+        self.tc = PID(0.1, 0.1, 0.1, mx=1.0) # kp, ki, kd
         
         # controller for steer
         self.yc = YawController(wheel_base, steer_ratio, min_speed, 
@@ -49,16 +50,16 @@ class Controller(object):
         
         error = target_linear_velocity - current_linear_velocity
         if error < 0.0:
-            # Need to brake
-            # TODO: Calculate this from target acceleration, in unit of torque (N*m)
-            brake = -3000
-            #
-            # It is not stopping quickly enough when calculating it like this... Need to investigate.
-            # torque = mass * accel * wheel radius
-            # Take a little extra mass into account, for gas/people/etc..
-            # brake = self.vehicle_mass * self.decel_limit * self.wheel_radius  # Note: decel_limit is negative
-            #if brake > self.brake_deadband: # tolerance on brake value...
-            #    brake = 0.0
+            # Need to brake - unit of torque (N*m)
+            #brake = -1E10 # apply high brake to come to full stop
+            decel = error/sample_time
+            brake = self.vehicle_mass * decel * self.wheel_radius  # Note: decel is negative            
+            #if target_linear_velocity <= 0.1:
+            #    brake = -1E6 # apply high brake to come to full stop
+            #else:
+            #    decel = error/sample_time
+            #    brake = self.vehicle_mass * decel * self.wheel_radius  # Note: decel is negative
+            
         else:    
             if sample_time > 0.0:
                 thc   = self.tc.step(error, sample_time)
@@ -66,8 +67,8 @@ class Controller(object):
                     throttle = thc
         
         if DEBUG:
-            rospy.logwarn("twist_controller: target_v, current_v, throttle, brake, steer = %e, %e %e, %e, %e",
-                          target_linear_velocity, current_linear_velocity, throttle, brake, steer)
+            rospy.logwarn("twist_controller: target_v, current_v, sample_time, throttle, brake, steer = %e, %e, %e %e, %e, %e",
+                          target_linear_velocity, current_linear_velocity, sample_time, throttle, brake, steer)
                
             
         steer = self.yc.get_steering(target_linear_velocity,

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -51,14 +51,8 @@ class Controller(object):
         error = target_linear_velocity - current_linear_velocity
         if error < 0.0:
             # Need to brake - unit of torque (N*m)
-            #brake = -1E10 # apply high brake to come to full stop
             decel = error/sample_time
             brake = self.vehicle_mass * decel * self.wheel_radius  # Note: decel is negative            
-            #if target_linear_velocity <= 0.1:
-            #    brake = -1E6 # apply high brake to come to full stop
-            #else:
-            #    decel = error/sample_time
-            #    brake = self.vehicle_mass * decel * self.wheel_radius  # Note: decel is negative
             
         else:    
             if sample_time > 0.0:

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import rospy
-from geometry_msgs.msg import PoseStamped
+from geometry_msgs.msg import PoseStamped, TwistStamped
 from styx_msgs.msg import Lane, Waypoint
 from std_msgs.msg import Int32
 
@@ -9,11 +9,17 @@ import numpy as np
 from scipy.spatial import distance
 from itertools import islice, cycle
 
-DEBUG = False              # get printout
+DEBUG = True              # get printout
 
-RED_LIGHT_DECEL = 0.05 # lower this number to stop car quicker at a light
-RED_LIGHT_CUTOFF= 0.1
-DISTANCE_LIGHT_IGNORE = 75.0
+NO_LIGHT = -10000000
+
+DISTANCE_LIGHT_IGNORE   = 100.0 # start slowing down at this distance
+DISTANCE_LIGHT_GREEN_GO = 10.0  # if light turns green and we are within this distance, go full speed ahead
+
+# we have these car states:
+NO_LIGHT_IN_SIGHT           = 0
+STOPPING_FOR_LIGHT          = 1
+ACCELERATING_THROUGH_LIGHT  = 2
 
 '''
 This node will publish waypoints from the car's current position to some `x` distance ahead.
@@ -43,6 +49,7 @@ class WaypointUpdater(object):
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
         rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb, queue_size=1)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb, queue_size=1)
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
@@ -52,15 +59,20 @@ class WaypointUpdater(object):
         
         self.base     = None   # base waypoints
         
-        self.red_light_stopline_wp_id = -1
+        self.car_pos = None
+        
+        self.next_light_stopline_wp_id = NO_LIGHT
+        self.light_is_red = False
+        
+        self.current_linear_velocity = 0.0
+        self.current_angular_velocity = 0.0        
+
+        self.car_state = None
+        self.previous_light = None
 
         rospy.spin()
 
     def pose_cb(self, msg):
-        # TODO: Implement
-        if DEBUG:
-            rospy.logwarn("===========================================================\n \
-                           Entered callback pose_cb \n")
         
         if self.base is None:
             return  # don't have base yet. 
@@ -74,7 +86,14 @@ class WaypointUpdater(object):
         #     v2: p1->car
         # - If dot product is positive then p2 is next waypoint else p1
         
-        car_pos = np.array( [[msg.pose.position.x, msg.pose.position.y, msg.pose.position.z]] ) # 2D array, valid for cdist
+        car_pos = [msg.pose.position.x, msg.pose.position.y, msg.pose.position.z]
+        #if car_pos == self.car_pos:
+        #    if self.current_linear_velocity <= 0.1:
+        #        return # car position didn't change since last callback, so no update needed, unless velocity is zero
+        #else:
+        #    self.car_pos = car_pos
+        
+        car_pos = np.array( [car_pos] ) # 2D array, valid for cdist
         dist    = distance.cdist(self.base_pos, car_pos)
         i1      = np.argmin(dist)
         if i1 == len(self.base_pos)-1:
@@ -92,34 +111,85 @@ class WaypointUpdater(object):
         if dot_product > 0: # i1 is behind car, so pick next one as start of final_waypoints
             i1 = i2
         
-        if self.red_light_stopline_wp_id != -1:
-            wps_to_stopline = list(islice(cycle(self.base.waypoints), i1, self.red_light_stopline_wp_id - 1))
+        if self.car_state is None and self.next_light_stopline_wp_id != NO_LIGHT:
+            if i1 > self.next_light_stopline_wp_id:
+                if DEBUG:
+                    rospy.logwarn("waypoint_updater: i1, stopline (NOT VALID YET) = %i, %i",
+                                  i1, self.next_light_stopline_wp_id)
+                    
+                return # non-valid light message. Don't publish anything yet...
+            
+        if self.next_light_stopline_wp_id != NO_LIGHT:
+            
+            if self.next_light_stopline_wp_id == self.previous_light:
+                same_light = True
+            else:
+                same_light = False
+                self.previous_light = self.next_light_stopline_wp_id
+                
+            wps_to_stopline = list(islice(cycle(self.base.waypoints), i1, self.next_light_stopline_wp_id - 1))
             distance_to_stopline = self.distance(wps_to_stopline,0,len(wps_to_stopline)-1)
-            if DEBUG:
-                rospy.logwarn("waypoint_updater: stop_line_wp_id, distance= %s, %f",str(self.red_light_stopline_wp_id), distance_to_stopline)
+            #if DEBUG:
+            #    rospy.logwarn("waypoint_updater: current_velocity, stop_line_wp_id, distance= %f, %s, %f",
+            #                  self.current_linear_velocity, str(self.next_light_stopline_wp_id), distance_to_stopline)
         
-        if (self.red_light_stopline_wp_id == -1 or 
-            distance_to_stopline>DISTANCE_LIGHT_IGNORE or
-            i1 > self.red_light_stopline_wp_id # car is already past the stop line... Keep going.
-            ):
-            # free & clear, drive at speed limit
-            final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
-            final_waypoints = self.drive_at_speed_limit(final_waypoints)        
+            if DEBUG:
+                rospy.logwarn("waypoint_updater: i1, stopline, is_red, distance = %i, %i, %i, %f",
+                              i1, self.next_light_stopline_wp_id, self.light_is_red, distance_to_stopline)
+                
+            if distance_to_stopline>DISTANCE_LIGHT_IGNORE:
+                self.car_state = NO_LIGHT_IN_SIGHT
+                final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
+                final_waypoints = self.drive_constant_speed(final_waypoints, self.velocity) 
+                if DEBUG:
+                    rospy.logwarn("waypoint_updater: No light in sight")                
+                    
+            elif (distance_to_stopline<DISTANCE_LIGHT_GREEN_GO and self.light_turned_green): # Only accelerate through if it just now turned green....
+                self.car_state = ACCELERATING_THROUGH_LIGHT
+                final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
+                final_waypoints = self.drive_constant_speed(final_waypoints, self.velocity) 
+                if DEBUG:
+                    rospy.logwarn("waypoint_updater: Accelerating through light")                
+            
+            elif (self.car_state == ACCELERATING_THROUGH_LIGHT and same_light):
+                self.car_state = ACCELERATING_THROUGH_LIGHT
+                final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
+                final_waypoints = self.drive_constant_speed(final_waypoints, self.velocity) 
+                if DEBUG:
+                    rospy.logwarn("waypoint_updater: Finish Accelerating through light")                                
+                    
+            else:
+                self.car_state = STOPPING_FOR_LIGHT
+                # waypoints up to the stopline + 5
+                ADD = 5
+                final_waypoints = list(islice(cycle(self.base.waypoints), i1, self.next_light_stopline_wp_id - 1 + ADD)) # add 5 waypoints passed stopping line
+                
+                for i in range(len(final_waypoints)):
+                    remaining = len(final_waypoints)-1 - i
+                    if remaining < 10+ADD: # Note we added waypoints passed stopping line.
+                        vel = 0.0
+                    elif remaining < 15+ADD:
+                        vel = 0.25
+                    elif remaining < 20+ADD:
+                        vel = 0.5
+                    else:
+                        vel = 1.0
+                    
+                    final_waypoints[i].twist.twist.linear.x = vel
+                if DEBUG:
+                    rospy.logwarn("waypoint_updater: Stopping for light")
+                    #self.print_waypoints_velocity(final_waypoints)                        
+                    
         else:
-            # stop at light waypoint for stopping line
-            final_waypoints = list(islice(cycle(self.base.waypoints), i1, self.red_light_stopline_wp_id - 1 ))
-            if len(final_waypoints) == 0 or len(final_waypoints) > LOOKAHEAD_WPS : # this can happen if car is at or past stopline already...
-                final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + 3 ))
-            final_waypoints = self.decelerate(final_waypoints)
-            # DEBUG
-            #self.print_waypoints_velocity(final_waypoints)
+            self.car_state == NO_LIGHT_IN_SIGHT
+            
+            final_waypoints = list(islice(cycle(self.base.waypoints), i1, i1 + LOOKAHEAD_WPS - 1))
+            final_waypoints = self.drive_constant_speed(final_waypoints, self.velocity)             
+            
             
         self.publish(final_waypoints)
             
-        if DEBUG: 
-            rospy.logwarn("Leaving callback pose_cb \n \
-                           ===========================================================\n")        
-
+        
     def waypoints_cb(self, msg):
         # TODO: Implement
         """
@@ -127,10 +197,6 @@ class WaypointUpdater(object):
         
         The msg contains a styx_msgs/Lane for all the waypoints of the base.
         """
-        if DEBUG:        
-            rospy.logwarn("===========================================================\n \
-                           Entering callback waypoints_cb \n") 
-            rospy.logwarn("# of waypoints = %s",len(msg.waypoints))
         
         # store waypoints data in numpy arrays
         base_pos = []     # Position:                  x, y, z
@@ -155,14 +221,23 @@ class WaypointUpdater(object):
         
         # store base_waypoints
         self.base = msg
-        
-        if DEBUG:   
-            rospy.logwarn("Leaving callback waypoints_cb \n \
-                           ===========================================================\n") 
                        
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement    
-        self.red_light_stopline_wp_id = msg.data # -1: no red light
+        if msg.data == NO_LIGHT:
+            self.next_light_stopline_wp_id = NO_LIGHT
+        else:
+            self.next_light_stopline_wp_id = abs(msg.data)
+            if msg.data > 0:
+                self.light_is_red       = True
+                self.light_turned_green = False
+            else:
+                if self.light_is_red == True:
+                    self.light_turned_green = True
+                else:
+                    self.light_turned_green = False
+                
+                self.light_is_red = False
 
     def obstacle_cb(self, msg):
         # TODO: Callback for /obstacle_waypoint message. We will implement it later
@@ -185,24 +260,55 @@ class WaypointUpdater(object):
     def kmph2mps(self, velocity_kmph):
         return (velocity_kmph * 1000.) / (60. * 60.)
     
-    def drive_at_speed_limit(self, waypoints):
+    def drive_constant_speed(self, waypoints, speed):
         for wp in waypoints:
-            wp.twist.twist.linear.x = self.velocity
+            wp.twist.twist.linear.x = speed
         return waypoints
                 
-    def decelerate(self, waypoints):  # NOTE: copied from waypoint_loader
-        last = waypoints[-1]
-        last.twist.twist.linear.x = 0.
-        last_id = len(waypoints)-1 
-        for i in range(last_id-1,-1,-1):
-            wp = waypoints[i]
-            dist = self.distance(waypoints, i, last_id)
-            vel = math.sqrt(2.0 * RED_LIGHT_DECEL * dist)
-            vel = min(self.velocity, vel) # limit it to the speed-limit
-            if vel < RED_LIGHT_CUTOFF:
-                vel = 0.
-            wp.twist.twist.linear.x = min(vel, wp.twist.twist.linear.x)  # TODO: Is this OK??
+    def decelerate(self, waypoints,deceleration):  # NOTE: copied from waypoint_loader    
+        for i in range(len(waypoints)):
+            remaining = len(waypoints)-1 - i
+            if remaining < 10: # Note we added 5 waypoints passed stopping line.
+                vel = 0.0
+            elif remaining < 15:
+                vel = 0.5
+            else:
+                vel = 2.0
+            
+            waypoints[i].twist.twist.linear.x = vel        
+        
         return waypoints
+    
+        #id_1 = len(waypoints)-1
+        #id_2 = len(waypoints)-2
+        #id_3 = len(waypoints)-3
+        #id_4 = len(waypoints)-4
+        #id_8 = len(waypoints)-8  
+        
+        #if id_1 >= 0: waypoints[id_1].twist.twist.linear.x = 0.
+        #if id_2 >= 0: waypoints[id_2].twist.twist.linear.x = 0.
+        #if id_3 >= 0: waypoints[id_3].twist.twist.linear.x = 0.
+         
+        #for i in range(id_4,id_8,-1):
+            #if i >= 0: 
+                #vel = 0.25
+                #waypoints[i].twist.twist.linear.x = vel
+        
+        #for i in range(id_8,-1,-1):
+            ##dist = self.distance(waypoints, i, id_3)
+            ##vel = math.sqrt(2.0 * deceleration * dist)
+            ##vel = min(self.velocity, vel) # limit it to the speed-limit
+            #if i >=0:
+                #vel = LIGHT_APPROACH_SPEED
+                #waypoints[i].twist.twist.linear.x = vel
+            
+        #return waypoints
+    
+    def constant_deceleration_to_reach_zero_speed(self, distance_to_stopline):
+        if distance_to_stopline > 0.0:
+            return 0.5*self.current_linear_velocity*self.current_linear_velocity/distance_to_stopline
+        else:
+            return 1.0
 
     def publish(self, waypoints):   # NOTE: copied from waypoint_loader
         lane = Lane()
@@ -213,10 +319,18 @@ class WaypointUpdater(object):
 
     def print_waypoints_velocity(self, waypoints):
         rospy.logwarn("waypoint_updater, waypoint velocities:\n")
-        for wp in waypoints:
+        last_id = len(waypoints)-1 
+        for i in range(last_id,-1,-1):
+            wp = waypoints[i]
             vel=wp.twist.twist.linear.x
             rospy.logwarn("%f, ",vel)
-        rospy.logwarn("\n")
+            
+    def current_velocity_cb(self, msg):
+        # msg type: TwistStamped
+        # Provides update on current velocity
+        self.current_linear_velocity = msg.twist.linear.x
+        self.current_angular_velocity = msg.twist.angular.z
+        pass     
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Settings are such that car slows down once 100m from a stop-light. This happens when the light is green or red, doesn't matter. I found that it is needed to slow down significantly to be able to stop on time and not go over the stopping-line in front of the light.

Once the car is within a close distance to the light, and it turns green, then a flag is set to accelerate through the light.

The distance when to start the slow-down, the slow-down profile, and the distance when it is allowed to accelerate through the light are parameters that we need to tune based on more testing.